### PR TITLE
feat: add CSS-based layout options and hideLogo option

### DIFF
--- a/MMM-GrafanaGauges.css
+++ b/MMM-GrafanaGauges.css
@@ -1,0 +1,17 @@
+.mmm-grafana-gauges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--mmm-grafana-gauges-gap, 0);
+}
+
+.mmm-grafana-gauges--align-left {
+    justify-content: flex-start;
+}
+
+.mmm-grafana-gauges--align-center {
+    justify-content: center;
+}
+
+.mmm-grafana-gauges--align-right {
+    justify-content: flex-end;
+}

--- a/MMM-GrafanaGauges.js
+++ b/MMM-GrafanaGauges.js
@@ -18,9 +18,15 @@ Module.register("MMM-GrafanaGauges", {
         this.scheduleUpdate(this.config.refreshInterval);
     },
 
+	// Define required CSS files.
+	getStyles() {
+		return ['MMM-GrafanaGauges.css']
+	},
+
     // Override dom generator.
     getDom: function() {
         var wrapper = document.createElement("div");
+        wrapper.className = "mmm-grafana-gauges";
         if (!this.config.host) {
             Log.error("MMM-GrafanaGauges: config.host is required");
             return wrapper;
@@ -40,7 +46,7 @@ Module.register("MMM-GrafanaGauges", {
             baseUrl = protocol + this.config.host + ":" + this.config.port + "/dashboard-solo/db/" + this.config.dashboardname + "?orgId=" + this.config.orgId;
         }
 
-        var hideLogo = this.config.hideLogo ? '&hideLogo=true' : '';
+        var hideLogo = this.config.hideLogo ? "&hideLogo=true" : "";
         var img = '';
         if (Array.isArray(this.config.showIDs) && this.config.showIDs.length > 0) {
             for (var i = 0; i < this.config.showIDs.length; i++) {
@@ -50,11 +56,14 @@ Module.register("MMM-GrafanaGauges", {
             Log.warn("MMM-GrafanaGauges: config.showIDs is empty or missing");
         }
 
-        var alignMap = { left: "flex-start", center: "center", right: "flex-end" };
-        wrapper.style.display = "flex";
-        wrapper.style.flexWrap = "wrap";
-        wrapper.style.justifyContent = alignMap[this.config.align] || "flex-start";
-        wrapper.style.gap = this.config.spacing;
+        var align = this.config.align || "left";
+        if (align !== "left" && align !== "center" && align !== "right") {
+            Log.warn("MMM-GrafanaGauges: invalid config.align value '" + align + "'. Allowed values: left, center, right. Falling back to left.");
+            align = "left";
+        }
+
+        wrapper.classList.add("mmm-grafana-gauges--align-" + align);
+        wrapper.style.setProperty("--mmm-grafana-gauges-gap", this.config.spacing || "0");
         wrapper.innerHTML = img;
         wrapper.setAttribute("timestamp", new Date().getTime());
         return wrapper;

--- a/MMM-GrafanaGauges.js
+++ b/MMM-GrafanaGauges.js
@@ -6,7 +6,9 @@ Module.register("MMM-GrafanaGauges", {
         refreshInterval: 900,
         animationSpeed: 1000,
         https: false,
-        version: 0
+        version: 0,
+        hideLogo: true,
+        spacing: "0"
     },
 
     // Define start sequence.
@@ -37,15 +39,19 @@ Module.register("MMM-GrafanaGauges", {
             baseUrl = protocol + this.config.host + ":" + this.config.port + "/dashboard-solo/db/" + this.config.dashboardname + "?orgId=" + this.config.orgId;
         }
 
+        var hideLogo = this.config.hideLogo ? '&hideLogo=true' : '';
         var img = '';
         if (Array.isArray(this.config.showIDs) && this.config.showIDs.length > 0) {
             for (var i = 0; i < this.config.showIDs.length; i++) {
-                img += '<iframe src="' + baseUrl + '&panelId=' + this.config.showIDs[i] + '" width="' + this.config.width + '" height="' + this.config.height + '" frameborder="0" scrolling="no"></iframe>';
+                img += '<iframe src="' + baseUrl + '&panelId=' + this.config.showIDs[i] + hideLogo + '" width="' + this.config.width + '" height="' + this.config.height + '" frameborder="0" scrolling="no"></iframe>';
             }
         } else {
             Log.warn("MMM-GrafanaGauges: config.showIDs is empty or missing");
         }
 
+        wrapper.style.display = "flex";
+        wrapper.style.flexWrap = "wrap";
+        wrapper.style.gap = this.config.spacing;
         wrapper.innerHTML = img;
         wrapper.setAttribute("timestamp", new Date().getTime());
         return wrapper;

--- a/MMM-GrafanaGauges.js
+++ b/MMM-GrafanaGauges.js
@@ -8,7 +8,8 @@ Module.register("MMM-GrafanaGauges", {
         https: false,
         version: 0,
         hideLogo: true,
-        spacing: "0"
+        spacing: "0",
+        align: "left"
     },
 
     // Define start sequence.
@@ -49,8 +50,10 @@ Module.register("MMM-GrafanaGauges", {
             Log.warn("MMM-GrafanaGauges: config.showIDs is empty or missing");
         }
 
+        var alignMap = { left: "flex-start", center: "center", right: "flex-end" };
         wrapper.style.display = "flex";
         wrapper.style.flexWrap = "wrap";
+        wrapper.style.justifyContent = alignMap[this.config.align] || "flex-start";
         wrapper.style.gap = this.config.spacing;
         wrapper.innerHTML = img;
         wrapper.setAttribute("timestamp", new Date().getTime());

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The following properties can be configured:
 | `width` | Width of the displayed chart. `'150 px'` or `'50 %'` are valid options. Default value: `"100%"`. |
 | `height` | Height of the displayed chart. `'150 px'` or `'50 %'` are valid options. Default value: `"100%"`. |
 | `refreshInterval` | Update interval of the diagram in seconds. Default value: `900` = 15 \* 60 (four times every hour). |
+| `hideLogo` | Append `hideLogo=true` to each panel URL. Set to `false` to leave it off. Default value: `true`. |
+| `spacing` | Gap between adjacent panels, as a CSS length (e.g. `"10px"`, `"1em"`). Default value: `"0"` (no gap). |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following properties can be configured:
 | `refreshInterval` | Update interval of the diagram in seconds. Default value: `900` = 15 \* 60 (four times every hour). |
 | `hideLogo` | Append `hideLogo=true` to each panel URL. Set to `false` to leave it off. Default value: `true`. |
 | `spacing` | Gap between adjacent panels, as a CSS length (e.g. `"10px"`, `"1em"`). Default value: `"0"` (no gap). |
+| `align` | Horizontal alignment of the panels: `"left"`, `"center"`, or `"right"`. Default value: `"left"`. |
 
 ## Development
 

--- a/demo.config.js
+++ b/demo.config.js
@@ -23,6 +23,8 @@ let config = {
         width: '220',
         height: '220',
         refreshInterval: 60,
+        hideLogo: true,
+        spacing: '10px',
       },
     },
   ],

--- a/demo.config.js
+++ b/demo.config.js
@@ -25,6 +25,7 @@ let config = {
         refreshInterval: 60,
         hideLogo: true,
         spacing: '10px',
+        align: 'center',
       },
     },
   ],


### PR DESCRIPTION
Adds 3 new configuration options and subsequent features:

1. **Horizontal Spacing** - Spacing between horizontal grafana objects in units of pixels. _Defaults to 0 so that existing behavior is unchanged._
2. **Logo Removal** - Optionally adds the query flag to remove the grafana logo in the top right of each grafana object. _Defaults to true because who wants this lol._
3. **Horizontal Alignment** - Left, right, or center spacing across the component parent relative to the center of the grafana objects. _Defaults to left so that existing behavior is unchanged._

These are super minor additions, but the spacing + alignment stuff is a position change that could screw up existing configurations. That being said, my testing in the demo environment and my actual mirror didn't show any such behavior!

Here's what I was able to implement using these changes on my dashboard!
<img width="750" height="250" alt="image" src="https://github.com/user-attachments/assets/28ab20a9-1906-4725-a6ab-804c5175d128" />
